### PR TITLE
Thread safety by using the default source for the RNG

### DIFF
--- a/address.go
+++ b/address.go
@@ -31,9 +31,8 @@ type Addresser interface {
 type Address struct{}
 
 func (i Address) Latitude(v reflect.Value) error {
-	r := rand.New(src)
 	kind := v.Kind()
-	val := (r.Float32() * 180) - 90
+	val := (rand.Float32() * 180) - 90
 	if kind == reflect.Float32 {
 		v.Set(reflect.ValueOf(val))
 		return nil
@@ -44,9 +43,8 @@ func (i Address) Latitude(v reflect.Value) error {
 }
 
 func (i Address) Longitude(v reflect.Value) error {
-	r := rand.New(src)
 	kind := v.Kind()
-	val := (r.Float32() * 360) - 180
+	val := (rand.Float32() * 360) - 180
 
 	if kind == reflect.Float32 {
 		v.Set(reflect.ValueOf(val))

--- a/faker.go
+++ b/faker.go
@@ -11,7 +11,6 @@ import (
 	"time"
 )
 
-var src = rand.NewSource(time.Now().UnixNano())
 var mu = &sync.Mutex{}
 
 const (
@@ -138,7 +137,6 @@ func FakeData(a interface{}) error {
 }
 
 func getValue(t reflect.Type) (reflect.Value, error) {
-	r := rand.New(src)
 	k := t.Kind()
 
 	switch k {
@@ -155,7 +153,7 @@ func getValue(t reflect.Type) (reflect.Value, error) {
 
 		switch t.String() {
 		case "time.Time":
-			ft := time.Now().Add(time.Duration(r.Int63()))
+			ft := time.Now().Add(time.Duration(rand.Int63()))
 			return reflect.ValueOf(ft), nil
 		default:
 			v := reflect.New(t).Elem()
@@ -182,7 +180,7 @@ func getValue(t reflect.Type) (reflect.Value, error) {
 		res := randomString(25)
 		return reflect.ValueOf(res), nil
 	case reflect.Array, reflect.Slice:
-		len := r.Intn(100)
+		len := rand.Intn(100)
 		v := reflect.MakeSlice(t, len, len)
 		for i := 0; i < v.Len(); i++ {
 			val, err := getValue(t.Elem())
@@ -193,41 +191,41 @@ func getValue(t reflect.Type) (reflect.Value, error) {
 		}
 		return v, nil
 	case reflect.Int:
-		return reflect.ValueOf(int(r.Intn(100))), nil
+		return reflect.ValueOf(int(rand.Intn(100))), nil
 	case reflect.Int8:
-		return reflect.ValueOf(int8(r.Intn(100))), nil
+		return reflect.ValueOf(int8(rand.Intn(100))), nil
 	case reflect.Int16:
-		return reflect.ValueOf(int16(r.Intn(100))), nil
+		return reflect.ValueOf(int16(rand.Intn(100))), nil
 	case reflect.Int32:
-		return reflect.ValueOf(int32(r.Intn(100))), nil
+		return reflect.ValueOf(int32(rand.Intn(100))), nil
 	case reflect.Int64:
-		return reflect.ValueOf(int64(r.Intn(100))), nil
+		return reflect.ValueOf(int64(rand.Intn(100))), nil
 	case reflect.Float32:
-		return reflect.ValueOf(r.Float32()), nil
+		return reflect.ValueOf(rand.Float32()), nil
 	case reflect.Float64:
-		return reflect.ValueOf(r.Float64()), nil
+		return reflect.ValueOf(rand.Float64()), nil
 	case reflect.Bool:
-		val := r.Intn(2) > 0
+		val := rand.Intn(2) > 0
 		return reflect.ValueOf(val), nil
 
 	case reflect.Uint:
-		return reflect.ValueOf(uint(r.Intn(100))), nil
+		return reflect.ValueOf(uint(rand.Intn(100))), nil
 
 	case reflect.Uint8:
-		return reflect.ValueOf(uint8(r.Intn(100))), nil
+		return reflect.ValueOf(uint8(rand.Intn(100))), nil
 
 	case reflect.Uint16:
-		return reflect.ValueOf(uint16(r.Intn(100))), nil
+		return reflect.ValueOf(uint16(rand.Intn(100))), nil
 
 	case reflect.Uint32:
-		return reflect.ValueOf(uint32(r.Intn(100))), nil
+		return reflect.ValueOf(uint32(rand.Intn(100))), nil
 
 	case reflect.Uint64:
-		return reflect.ValueOf(uint64(r.Intn(100))), nil
+		return reflect.ValueOf(uint64(rand.Intn(100))), nil
 
 	case reflect.Map:
 		v := reflect.MakeMap(t)
-		len := r.Intn(100)
+		len := rand.Intn(100)
 		for i := 0; i < len; i++ {
 			key, err := getValue(t.Key())
 			if err != nil {
@@ -294,9 +292,9 @@ func userDefinedInt(v reflect.Value, tag string) error {
 
 func randomString(n int) string {
 	b := make([]byte, n)
-	for i, cache, remain := n-1, src.Int63(), letterIdxMax; i >= 0; {
+	for i, cache, remain := n-1, rand.Int63(), letterIdxMax; i >= 0; {
 		if remain == 0 {
-			cache, remain = src.Int63(), letterIdxMax
+			cache, remain = rand.Int63(), letterIdxMax
 		}
 		if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
 			b[i] = letterBytes[idx]
@@ -315,9 +313,9 @@ func randomElementFromSliceString(s []string) string {
 }
 func randomStringNumber(n int) string {
 	b := make([]byte, n)
-	for i, cache, remain := n-1, src.Int63(), letterIdxMax; i >= 0; {
+	for i, cache, remain := n-1, rand.Int63(), letterIdxMax; i >= 0; {
 		if remain == 0 {
-			cache, remain = src.Int63(), letterIdxMax
+			cache, remain = rand.Int63(), letterIdxMax
 		}
 		if idx := int(cache & letterIdxMask); idx < len(numberBytes) {
 			b[i] = numberBytes[idx]

--- a/faker.go
+++ b/faker.go
@@ -111,6 +111,10 @@ var ErrMoreArguments = "Passed more arguments than is possible : (%d)"
 
 var ErrNotSupportedPointer = "Use sample:=new(%s)\n faker.FakeData(sample) instead"
 
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
 // FakeData is the main function. Will generate a fake data based on your struct.  You can use this for automation testing, or anything that need automated data.
 // You don't need to Create your own data for your testing.
 func FakeData(a interface{}) error {

--- a/internet.go
+++ b/internet.go
@@ -55,10 +55,9 @@ func (internet Internet) Email() string {
 	return randomString(7) + "@" + randomString(5) + "." + randomElementFromSliceString(tld)
 }
 func (internet Internet) MacAddress() string {
-	r := rand.New(src)
 	ip := make([]byte, 6)
 	for i := 0; i < 6; i++ {
-		ip[i] = byte(r.Intn(256))
+		ip[i] = byte(rand.Intn(256))
 	}
 
 	return net.HardwareAddr(ip).String()
@@ -79,20 +78,18 @@ func (internet Internet) UserName() string {
 	return randomString(7)
 }
 func (internet Internet) Ipv4() string {
-	r := rand.New(src)
 	size := 4
 	ip := make([]byte, size)
 	for i := 0; i < size; i++ {
-		ip[i] = byte(r.Intn(256))
+		ip[i] = byte(rand.Intn(256))
 	}
 	return net.IP(ip).To4().String()
 }
 func (internet Internet) Ipv6() string {
-	r := rand.New(src)
 	size := 16
 	ip := make([]byte, size)
 	for i := 0; i < size; i++ {
-		ip[i] = byte(r.Intn(256))
+		ip[i] = byte(rand.Intn(256))
 	}
 	return net.IP(ip).To16().String()
 }

--- a/payment.go
+++ b/payment.go
@@ -54,7 +54,6 @@ type Payment struct{}
 
 func (p Payment) CreditCardType() string {
 	n := len(creditCards)
-	r := rand.New(src)
 	if cacheCreditCard != "" {
 		return cacheCreditCard
 	}
@@ -63,17 +62,16 @@ func (p Payment) CreditCardType() string {
 	for _, cc := range creditCards {
 		ccTypes = append(ccTypes, cc.ccType)
 	}
-	cacheCreditCard = ccTypes[r.Intn(n)]
+	cacheCreditCard = ccTypes[rand.Intn(n)]
 	return cacheCreditCard
 }
 
 // CreditCardNum generated credit card number according to the card number rules
 func (p Payment) CreditCardNumber() string {
-	r := rand.New(src)
 	ccType := strings.ToLower(p.CreditCardType())
 	cacheCreditCard = ccType
 	card := creditCards[ccType]
-	prefix := strconv.Itoa(card.prefixes[r.Intn(len(card.prefixes))])
+	prefix := strconv.Itoa(card.prefixes[rand.Intn(len(card.prefixes))])
 
 	num := prefix
 	digit := randomStringNumber(card.length - len(prefix))


### PR DESCRIPTION
* Using custom sources results in the RNG becoming non-thread safe. Using the default source guarantees that multiple threads are able to generate data using faker safely as per the Go docs (https://golang.org/pkg/math/rand/).