### PR TITLE
Bugfix: DayOfWeek now returns random day

### DIFF
--- a/datetime.go
+++ b/datetime.go
@@ -593,12 +593,14 @@ var timezones = []string{
 	"Asia/Yekaterinburg",
 }
 
+// These example values must use the reference time "Mon Jan 2 15:04:05 MST 2006"
+// as described at https://gobyexample.com/time-formatting-parsing
 const (
 	BaseDate   = "2006-01-02"
 	Time       = "15:04:05"
 	Month      = "January"
 	Year       = "2006"
-	Day        = "Sunday"
+	Day        = "Monday"
 	DayOfMonth = "_2"
 	TimePeriod = "PM"
 )

--- a/datetime_test.go
+++ b/datetime_test.go
@@ -2,11 +2,13 @@ package faker
 
 import (
 	"fmt"
-	"github.com/bxcodec/faker/support/slice"
 	"log"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/bxcodec/faker/support/slice"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSetDateTimer(t *testing.T) {
@@ -80,6 +82,17 @@ func TestDayOfWeek(t *testing.T) {
 	if err != nil {
 		t.Error("function DayOfWeek need return valid day")
 	}
+}
+
+func TestDayOfWeekReturnsDifferentValues(t *testing.T) {
+	dayMap := make(map[string]struct{})
+	iterations := 5 // sufficiently large to assure we don't randomly get the same value again
+	for i := 0; i < iterations; i++ {
+		day := GetDateTimer().DayOfWeek()
+		//t.Log(day)
+		dayMap[day] = struct{}{}
+	}
+	assert.True(t, len(dayMap) > 1)
 }
 
 func TestDayOfMonth(t *testing.T) {


### PR DESCRIPTION
Previously using the `day_of_week` tag, as in
```
DayString string `faker:"day_of_week"`
```
would always return `Sunday`. Tracked this down to the fact that the code needs to use constants from the reference time `"Mon Jan 2 15:04:05 MST 2006"` as described https://gobyexample.com/time-formatting-parsing. So the correct value to use is `Monday`.

Also included in this PR one way to test that we are not always getting the same value returned from the function. 