### PR TITLE
adds support for FirstName of either male or female gender

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Supported tag:
 * IP Address (IPV4 IPV6 )
 * Password
 
- 
+
 **Payment :**
 * Credit Card Type (VISA, MASTERCARD , AMERICAN EXPRESS ,DISCOVER)
 * Credit Card Number
@@ -64,6 +64,7 @@ Supported tag:
 **Person :**
 * Title male
 * Title female
+* FirstName
 * FirstName male
 * FirstName female
 * LastName
@@ -104,7 +105,7 @@ type SomeStruct struct {
  Email            string  `faker:"email"`
  IPV4             string  `faker:"ipv4"`
  IPV6             string  `faker:"ipv6"`
- Password         string  `faker:"password"` 
+ Password         string  `faker:"password"`
  PhoneNumber      string  `faker:"phone_number"`
  MacAddress       string  `faker:"mac_address"`
  Url              string  `faker:"url"`
@@ -113,6 +114,7 @@ type SomeStruct struct {
  E164PhoneNumber  string  `faker:"e_164_phone_number"`
  TitleMale        string  `faker:"title_male"`
  TitleFemale      string  `faker:"title_female"`
+ FirstName        string  `faker:"first_name"`
  FirstNameMale    string  `faker:"first_name_male"`
  FirstNameFemale  string  `faker:"first_name_female"`
  LastName         string  `faker:"last_name"`
@@ -158,6 +160,7 @@ func main() {
         E164PhoneNumber: +765101283947,
         TitleMale: Prof.,
         TitleFemale: Dr.,
+        FirstName: Benny,
         FirstNameMale: Charley,
         FirstNameFemale: Freeda,
         LastName: Runte,
@@ -254,7 +257,7 @@ BenchmarkFakerDataNOTTagged-4             500000              3049 ns/op        
 The Struct Field must PUBLIC.<br>
 Support Only For :
 * int  int8  int16  int32  int64
-* []int  []int8  []int16  []int32  []int64  
+* []int  []int8  []int16  []int32  []int64
 * bool []bool
 * string []string
 * float32 float64 []float32 []float64
@@ -264,15 +267,15 @@ Support Only For :
 ## Limitation
 Unfortunately this library has some limitation
 * Not support for private field. Just make sure your field's struct is public. If not, it will throw panic error.
-* Not support for `interface{}` data type. How we can generate if we don't know what is the data type? 
-* Not support for `map[interface{}]interface{}, map[any_type]interface{}, map[interface{}]any_type`. Still, it's about interface. We can't give you something if we don't know what really you want. 
-* Not fully support for custom type, but a few custom type already supported, still investigating how to do this in the correct ways. For now, if you use `faker`, it's safer not to use any custom type to avoid panic. 
+* Not support for `interface{}` data type. How we can generate if we don't know what is the data type?
+* Not support for `map[interface{}]interface{}, map[any_type]interface{}, map[interface{}]any_type`. Still, it's about interface. We can't give you something if we don't know what really you want.
+* Not fully support for custom type, but a few custom type already supported, still investigating how to do this in the correct ways. For now, if you use `faker`, it's safer not to use any custom type to avoid panic.
 
 ## Contribution
 To contrib on this project, you can make a PR or just an issue.
 
 ### Maintainer
-- <a href="https://github.com/bxcodec">  **Iman Tumorang** </a> <br> 
-- <a href="https://github.com/agoalofalife">  **Ilya** </a> <br> 
+- <a href="https://github.com/bxcodec">  **Iman Tumorang** </a> <br>
+- <a href="https://github.com/agoalofalife">  **Ilya** </a> <br>
 
 

--- a/faker.go
+++ b/faker.go
@@ -36,6 +36,7 @@ const (
 	E164_PHONE_NUMBER  = "e_164_phone_number"
 	TITLE_MALE         = "title_male"
 	TITLE_FEMALE       = "title_female"
+	FIRST_NAME         = "first_name"
 	FIRST_NAME_MALE    = "first_name_male"
 	FIRST_NAME_FEMALE  = "first_name_female"
 	LAST_NAME          = "last_name"
@@ -74,6 +75,7 @@ var mapperTag = map[string]interface{}{
 	E164_PHONE_NUMBER:  GetPhoner().E164PhoneNumber,
 	TITLE_MALE:         GetPerson().TitleMale,
 	TITLE_FEMALE:       GetPerson().TitleFeMale,
+	FIRST_NAME:         GetPerson().FirstName,
 	FIRST_NAME_MALE:    GetPerson().FirstNameMale,
 	FIRST_NAME_FEMALE:  GetPerson().FirstNameFemale,
 	LAST_NAME:          GetPerson().LastName,

--- a/faker_test.go
+++ b/faker_test.go
@@ -82,6 +82,7 @@ type TaggedStruct struct {
 	E164PhoneNumber  string  `faker:"e_164_phone_number"`
 	TitleMale        string  `faker:"title_male"`
 	TitleFemale      string  `faker:"title_female"`
+	FirstName        string  `faker:"first_name"`
 	FirstNameMale    string  `faker:"first_name_male"`
 	FirstNameFemale  string  `faker:"first_name_female"`
 	LastName         string  `faker:"last_name"`
@@ -120,6 +121,7 @@ func (t TaggedStruct) String() string {
 	E164PhoneNumber: %s,
 	TitleMale: %s,
 	TitleFemale: %s,
+	FirstName: %s,
 	FirstNameMale: %s,
 	FirstNameFemale: %s,
 	LastName: %s,
@@ -143,7 +145,7 @@ func (t TaggedStruct) String() string {
 		t.IPV6, t.Password, t.PhoneNumber, t.MacAddress,
 		t.Url, t.UserName, t.ToolFreeNumber,
 		t.E164PhoneNumber, t.TitleMale, t.TitleFemale,
-		t.FirstNameMale, t.FirstNameFemale, t.LastName,
+		t.FirstName, t.FirstNameMale, t.FirstNameFemale, t.LastName,
 		t.Name, t.UnixTime, t.Date,
 		t.Time, t.MonthName, t.Year, t.DayOfWeek,
 		t.DayOfMonth, t.Timestamp, t.Century, t.TimeZone,

--- a/person.go
+++ b/person.go
@@ -8,6 +8,7 @@ import (
 type Dowser interface {
 	TitleMale() string
 	TitleFeMale() string
+	FirstName() string
 	FirstNameMale() string
 	FirstNameFemale() string
 	LastName() string
@@ -75,6 +76,9 @@ var firstNamesFemale = []string{
 	"Yadira", "Yasmeen", "Yasmin", "Yasmine", "Yazmin", "Yesenia", "Yessenia", "Yolanda", "Yoshiko", "Yvette", "Yvonne",
 	"Zaria", "Zelda", "Zella", "Zelma", "Zena", "Zetta", "Zita", "Zoe", "Zoey", "Zoie", "Zoila", "Zola", "Zora", "Zula",
 }
+
+var firstNames = append(firstNamesMale, firstNamesFemale...)
+
 var lastNames = []string{
 	"Abbott", "Abernathy", "Abshire", "Adams", "Altenwerth", "Anderson", "Ankunding", "Armstrong", "Auer", "Aufderhar",
 	"Bahringer", "Bailey", "Balistreri", "Barrows", "Bartell", "Bartoletti", "Barton", "Bashirian", "Batz", "Bauch", "Baumbach", "Bayer", "Beahan", "Beatty", "Bechtelar", "Becker", "Bednar", "Beer", "Beier", "Berge", "Bergnaum", "Bergstrom", "Bernhard", "Bernier", "Bins", "Blanda", "Blick", "Block", "Bode", "Boehm", "Bogan", "Bogisich", "Borer", "Bosco", "Botsford", "Boyer", "Boyle", "Bradtke", "Brakus", "Braun", "Breitenberg", "Brekke", "Brown", "Bruen", "Buckridge",
@@ -124,6 +128,10 @@ func (p Person) TitleMale() string {
 
 func (p Person) TitleFeMale() string {
 	return randomElementFromSliceString(titlesFemale)
+}
+
+func (p Person) FirstName() string {
+	return randomElementFromSliceString(firstNames)
 }
 
 func (p Person) FirstNameMale() string {

--- a/person_test.go
+++ b/person_test.go
@@ -1,8 +1,9 @@
 package faker
 
 import (
-	"github.com/bxcodec/faker/support/slice"
 	"testing"
+
+	"github.com/bxcodec/faker/support/slice"
 )
 
 func TestSetDowser(t *testing.T) {
@@ -34,6 +35,13 @@ func TestFirstNameFemale(t *testing.T) {
 	p := GetPerson()
 	if !slice.Contains(firstNamesFemale, p.FirstNameFemale()) {
 		t.Error("Expected value from variable firstNamesFemale in function FirstNameFemale")
+	}
+}
+
+func TestFirstName(t *testing.T) {
+	p := GetPerson()
+	if !slice.Contains(firstNames, p.FirstName()) {
+		t.Error("Expected value from either firstNamesMale or firstNamesFemale in function FirstName")
 	}
 }
 


### PR DESCRIPTION
I need to generate a random first name of either gender, so added support for that here. From a user perspective, if they choose to define a struct with either TitleMale or TitleFemale, they should also use FirstNameMale or FirstNameFemale.

But if they only need a FirstName and a LastName, this makes it possible to generate Persons of random gender. 