### PR TITLE
fix: fake data generation for custom scalar type pointers

### DIFF
--- a/faker.go
+++ b/faker.go
@@ -113,7 +113,7 @@ var mapperTag = map[string]interface{}{
 // 		ErrUnsupportedKind: Error on passing unsupported kind
 // 		ErrValueNotPtr: Error when value is not pointer
 // 		ErrTagNotSupported: Error when tag is not supported
-//		ErrTagAlreadyExists: Error when tag exists and call AddProvider
+// 		ErrTagAlreadyExists: Error when tag exists and call AddProvider
 // 		ErrMoreArguments: Error on passing more arguments
 // 		ErrNotSupportedPointer: Error when passing unsupported pointer
 var (
@@ -151,7 +151,7 @@ func FakeData(a interface{}) error {
 		return err
 	}
 
-	rval.Elem().Set(finalValue)
+	rval.Elem().Set(finalValue.Convert(reflectType.Elem()))
 	return nil
 }
 
@@ -171,13 +171,12 @@ func getValue(t reflect.Type) (reflect.Value, error) {
 
 	switch k {
 	case reflect.Ptr:
-
 		v := reflect.New(t.Elem())
 		val, err := getValue(t.Elem())
 		if err != nil {
 			return reflect.Value{}, err
 		}
-		v.Elem().Set(val)
+		v.Elem().Set(val.Convert(t.Elem()))
 		return v, nil
 	case reflect.Struct:
 

--- a/faker_test.go
+++ b/faker_test.go
@@ -388,6 +388,32 @@ func TestUnexportedFieldStruct(t *testing.T) {
 	fmt.Printf(" A value: %+v , SampleStruct Value: %+v  ", a, a)
 }
 
+func TestPointerToCustomScalar(t *testing.T) {
+	// This test is to ensure that the faker won't panic if trying to fake data on struct that has field
+	a := new(CustomInt)
+	err := FakeData(a)
+
+	if err != nil {
+		t.Error("Expected Not Error, But Got: ", err)
+	}
+	fmt.Printf(" A value: %+v , Custom scalar Value: %+v  ", a, a)
+}
+
+type PointerCustomIntStruct struct {
+	V *CustomInt
+}
+
+func TestPointerToCustomIntStruct(t *testing.T) {
+	// This test is to ensure that the faker won't panic if trying to fake data on struct that has field
+	a := new(PointerCustomIntStruct)
+	err := FakeData(a)
+
+	if err != nil {
+		t.Error("Expected Not Error, But Got: ", err)
+	}
+	fmt.Printf(" A value: %+v , PointerCustomIntStruct scalar Value: %+v  ", a, a)
+}
+
 func TestSkipField(t *testing.T) {
 	// This test is to ensure that the faker won't fill field with tag skip
 


### PR DESCRIPTION
There was a panic while faker tries to generate data for custom scalar type pointers