### PR TITLE
Add support for keeping struct property values

### DIFF
--- a/faker.go
+++ b/faker.go
@@ -32,7 +32,7 @@ type numberBoundary struct {
 	end   int
 }
 
-// Supported tag
+// Supported tags
 const (
 	letterIdxBits         = 6                    // 6 bits to represent a letter index
 	letterIdxMask         = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
@@ -181,7 +181,7 @@ var mapperTag = map[string]TaggedFunction{
 	HyphenatedID:          GetIdentifier().Hyphenated,
 }
 
-// Generic Error Messages for tag
+// Generic Error Messages for tags
 // 		ErrUnsupportedKindPtr: Error when get fake from ptr
 // 		ErrUnsupportedKind: Error on passing unsupported kind
 // 		ErrValueNotPtr: Error when value is not pointer

--- a/faker_test.go
+++ b/faker_test.go
@@ -820,16 +820,31 @@ func TestTagWithPointer(t *testing.T) {
 	}
 }
 
+func TestItOverwritesDefaultValueIfKeepIsSet(t *testing.T) {
+	type TestStruct struct {
+		Email     string `json:"email,omitempty" faker:"email,keep"`
+	}
+
+	test := TestStruct{}
+
+	err := FakeData(&test)
+	if err != nil {
+		t.Error("expected not error, but got: ", err)
+	}
+
+	if test.Email == "" {
+		t.Error("expected filled but got empty")
+	}
+}
 func TestItKeepsStructPropertyWhenTagKeepIsSet(t *testing.T) {
 	type TestStruct struct {
 		FirstName string `json:"first_name,omitempty" faker:"first_name_male,keep"`
-		Email     string `json:"email,omitempty" faker:"email"`
+		Email     string `json:"email,omitempty" faker:"email,keep"`
 	}
 
 	firstName := "Heino van der Laien"
 	test := TestStruct{
 		FirstName: firstName,
-		Email:     "heino@me.com",
 	}
 
 	err := FakeData(&test)
@@ -843,5 +858,32 @@ func TestItKeepsStructPropertyWhenTagKeepIsSet(t *testing.T) {
 
 	if test.Email == "" {
 		t.Error("expected filled but got empty")
+	}
+}
+
+func TestItThrowsAnErrorWhenKeepIsUsedOnUncomparableType(t *testing.T) {
+	type TypeStructWithStruct struct {
+		Struct struct{} `faker:"first_name_male,keep"`
+	}
+	type TypeStructWithMap struct {
+		Map map[string]string `faker:"first_name_male,keep"`
+	}
+	type TypeStructWithSlice struct {
+		Slice []string `faker:"first_name_male,keep"`
+	}
+	type TypeStructWithArray struct {
+		Array [4]string `faker:"first_name_male,keep"`
+	}
+
+	withStruct := TypeStructWithStruct{}
+	withMap := TypeStructWithMap{}
+	withSlice := TypeStructWithSlice{}
+	withArray := TypeStructWithArray{}
+
+	for _, item := range []interface{}{withArray,withStruct,withMap,withSlice} {
+		err := FakeData(&item)
+		if err == nil {
+			t.Errorf("expected error, but got nil")
+		}
 	}
 }

--- a/faker_test.go
+++ b/faker_test.go
@@ -297,9 +297,9 @@ func TestUnsuportedMapStringInterface(t *testing.T) {
 	type Sample struct {
 		Map map[string]interface{}
 	}
-	sample := new(Sample)
+	var sample = new(Sample)
 	if err := FakeData(sample); err == nil {
-		t.Error("Expected Got Error. But got nil")
+		t.Error("Expected Error. But got nil")
 	}
 }
 
@@ -817,5 +817,31 @@ func TestTagWithPointer(t *testing.T) {
 
 	if sample.School == nil || sample.School.Location == "" {
 		t.Error("Expected filled but got emtpy")
+	}
+}
+
+func TestOmitSetTagOmitsAlreadySetStructField(t *testing.T) {
+	type TestStruct struct {
+		FirstName string `json:"first_name,omitempty" faker:"first_name_male,omitset"`
+		Email     string `json:"email,omitempty" faker:"email"`
+	}
+
+	firstName := "Heino"
+	test := TestStruct{
+		FirstName: firstName,
+		Email:     "heino@me.com",
+	}
+
+	err := FakeData(&test)
+	if err != nil {
+		t.Error("expected not error, but got: ", err)
+	}
+
+	if test.FirstName != firstName {
+		t.Fatalf("expected: %s, but got: %s", firstName, test.FirstName)
+	}
+
+	if test.Email == "" {
+		t.Error("expected filled but got empty")
 	}
 }

--- a/faker_test.go
+++ b/faker_test.go
@@ -861,7 +861,7 @@ func TestItKeepsStructPropertyWhenTagKeepIsSet(t *testing.T) {
 	}
 }
 
-func TestItThrowsAnErrorWhenKeepIsUsedOnUncomparableType(t *testing.T) {
+func TestItThrowsAnErrorWhenKeepIsUsedOnIncomparableType(t *testing.T) {
 	type TypeStructWithStruct struct {
 		Struct struct{} `faker:"first_name_male,keep"`
 	}
@@ -885,5 +885,31 @@ func TestItThrowsAnErrorWhenKeepIsUsedOnUncomparableType(t *testing.T) {
 		if err == nil {
 			t.Errorf("expected error, but got nil")
 		}
+	}
+}
+
+func TestItThrowsAnErrorWhenPointerToInterfaceIsUsed(t *testing.T) {
+	type PtrToInterface struct {
+		Interface *interface{}
+	}
+
+	interfacePtr := PtrToInterface{}
+
+	err := FakeData(&interfacePtr)
+	if err == nil {
+		t.Errorf("expected error, but got nil")
+	}
+}
+
+func TestItThrowsAnErrorWhenZeroValueWithKeepAndUnsupportedTagIsUsed(t *testing.T) {
+	type String struct {
+		StringVal string `faker:"keep,unsupported"`
+	}
+
+	val := String{}
+
+	err := FakeData(&val)
+	if err == nil {
+		t.Errorf("expected error, but got nil")
 	}
 }

--- a/faker_test.go
+++ b/faker_test.go
@@ -820,13 +820,13 @@ func TestTagWithPointer(t *testing.T) {
 	}
 }
 
-func TestOmitSetTagOmitsAlreadySetStructField(t *testing.T) {
+func TestItKeepsStructPropertyWhenTagKeepIsSet(t *testing.T) {
 	type TestStruct struct {
-		FirstName string `json:"first_name,omitempty" faker:"first_name_male,omitset"`
+		FirstName string `json:"first_name,omitempty" faker:"first_name_male,keep"`
 		Email     string `json:"email,omitempty" faker:"email"`
 	}
 
-	firstName := "Heino"
+	firstName := "Heino van der Laien"
 	test := TestStruct{
 		FirstName: firstName,
 		Email:     "heino@me.com",


### PR DESCRIPTION
Sometimes I want to keep the original value of a struct property. Therefore I added a tag `keep` which allows me to keep the initially set value. It still sets the value if it is the zero value of a field.
