### PR TITLE
fix: 0 not valid for random size

### DIFF
--- a/faker.go
+++ b/faker.go
@@ -206,6 +206,7 @@ var (
 	ErrMoreArguments       = "Passed more arguments than is possible : (%d)"
 	ErrNotSupportedPointer = "Use sample:=new(%s)\n faker.FakeData(sample) instead"
 	ErrSmallerThanZero     = "Size:%d is smaller than zero."
+	ErrSmallerThanOne     = "Size:%d is smaller than one."
 	ErrUniqueFailure       = "Failed to generate a unique value for field \"%s\""
 
 	ErrStartValueBiggerThanEnd = "Start value can not be bigger than end value."
@@ -245,8 +246,8 @@ func SetRandomStringLength(size int) error {
 
 // SetRandomMapAndSliceSize sets the size for maps and slices for random generation.
 func SetRandomMapAndSliceSize(size int) error {
-	if size < 0 {
-		return fmt.Errorf(ErrSmallerThanZero, size)
+	if size < 1 {
+		return fmt.Errorf(ErrSmallerThanOne, size)
 	}
 	randomSize = size
 	return nil


### PR DESCRIPTION
Current code accepts 0 as a valid number for `SetRandomMapAndSliceSize` then panics on the Intn call with `panic: invalid argument to Intn`