### PR TITLE
bugfix(faker): don't panic on typed array

### DIFF
--- a/example_custom_faker_test.go
+++ b/example_custom_faker_test.go
@@ -18,9 +18,9 @@ type CustomUUID []byte
 
 // Sample ...
 type Sample struct {
-	ID        int64     `faker:"customIdFaker"`
-	Gondoruwo Gondoruwo `faker:"gondoruwo"`
-	Danger    string    `faker:"danger"`
+	ID        int64      `faker:"customIdFaker"`
+	Gondoruwo Gondoruwo  `faker:"gondoruwo"`
+	Danger    string     `faker:"danger"`
 	UUID      CustomUUID `faker:"customUUID"`
 }
 
@@ -42,8 +42,8 @@ func CustomGenerator() {
 	})
 
 	_ = faker.AddProvider("customUUID", func(v reflect.Value) (interface{}, error) {
-		s := []byte {
-			0,8,7,2,3,
+		s := []byte{
+			0, 8, 7, 2, 3,
 		}
 		return s, nil
 	})

--- a/faker.go
+++ b/faker.go
@@ -467,12 +467,23 @@ func getValue(a interface{}) (reflect.Value, error) {
 	case reflect.String:
 		res := randomString(randomStringLen, &lang)
 		return reflect.ValueOf(res), nil
-	case reflect.Array, reflect.Slice:
+	case reflect.Slice:
 		len := randomSliceAndMapSize()
 		if shouldSetNil && len == 0 {
 			return reflect.Zero(t), nil
 		}
 		v := reflect.MakeSlice(t, len, len)
+		for i := 0; i < v.Len(); i++ {
+			val, err := getValue(v.Index(i).Interface())
+			if err != nil {
+				return reflect.Value{}, err
+			}
+			val = val.Convert(v.Index(i).Type())
+			v.Index(i).Set(val)
+		}
+		return v, nil
+	case reflect.Array:
+		v := reflect.New(t).Elem()
 		for i := 0; i < v.Len(); i++ {
 			val, err := getValue(v.Index(i).Interface())
 			if err != nil {

--- a/faker_test.go
+++ b/faker_test.go
@@ -972,7 +972,7 @@ func TestExtend(t *testing.T) {
 	t.Run("test-with-custom-slice-type", func(t *testing.T) {
 		a := CustomThatUsesSlice{}
 		err := AddProvider("custom-type-over-slice", func(v reflect.Value) (interface{}, error) {
-			return []byte{0,1,2,3,4}, nil
+			return []byte{0, 1, 2, 3, 4}, nil
 		})
 
 		if err != nil {
@@ -985,7 +985,7 @@ func TestExtend(t *testing.T) {
 			t.Error("Expected Not Error, But Got: ", err)
 		}
 
-		if reflect.DeepEqual(a.UUID, []byte{0,1,2,3,4}) {
+		if reflect.DeepEqual(a.UUID, []byte{0, 1, 2, 3, 4}) {
 			t.Error("UUID should equal test value")
 		}
 	})

--- a/faker_test.go
+++ b/faker_test.go
@@ -29,6 +29,8 @@ var (
 
 type SomeInt32 int32
 
+type TArray [16]byte
+
 type SomeStruct struct {
 	Inta    int
 	Int8    int8
@@ -65,6 +67,7 @@ type SomeStruct struct {
 	SFloat64           []float64
 	SBool              []bool
 	Struct             AStruct
+	TArray             TArray
 	Time               time.Time
 	Stime              []time.Time
 	Currency           string  `faker:"currency"`


### PR DESCRIPTION
`go fmt` + fixed error:
```
$ cat > /tmp/1.go <<EOF
package main
import "github.com/bxcodec/faker"
type array [16]byte
func main() {
        var a array
        faker.FakeData(&a)
}
EOF

$ go run /tmp/1.go
panic: reflect.MakeSlice of non-slice type

goroutine 1 [running]:
reflect.MakeSlice(0x53d860, 0x4eed00, 0xd, 0xd, 0x0, 0x0, 0x0)
        /home/xaionaro/.gimme/versions/go1.13.linux.amd64/src/reflect/value.go:2256 +0x1d8
github.com/bxcodec/faker.getValue(0x4eed00, 0xc0000163a0, 0x191, 0x4eed01, 0x4eed00, 0xc0000163a0, 0x20300000000000)
        /home/xaionaro/go/src/github.com/bxcodec/faker/faker.go:444 +0xca0
github.com/bxcodec/faker.getValue(0x4dea40, 0xc000016380, 0xc00000e240, 0xc00000e220, 0x40c556, 0xc00000e1e0, 0xc00000e1c0)
        /home/xaionaro/go/src/github.com/bxcodec/faker/faker.go:355 +0x169e
github.com/bxcodec/faker.FakeData(0x4dea40, 0xc000016380, 0x56e00, 0xc0000240b8)
        /home/xaionaro/go/src/github.com/bxcodec/faker/faker.go:280 +0x1c6
main.main()
        /tmp/1.go:6 +0x3d
exit status 2
```