### PR TITLE
feat: Implement oneof tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Faker will generate you a fake data based on your Struct.
 [![License](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/bxcodec/faker/blob/master/LICENSE)
 [![GoDoc](https://godoc.org/github.com/bxcodec/faker?status.svg)](https://godoc.org/github.com/bxcodec/faker)
 [![Go.Dev](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white)](https://pkg.go.dev/github.com/bxcodec/faker/v3?tab=doc)
- 
+
 ## Index
 
 * [Support](#support)
@@ -38,8 +38,8 @@ go get -u github.com/bxcodec/faker/v3
 # Example
 
 ---
- 
- - Using Struct's tag: 
+
+ - Using Struct's tag:
    - [basic tags: example_with_tags_test.go](/example_with_tags_test.go)
    - [length and bounds: example_with_tags_lenbounds_test.go](/example_with_tags_lenbounds_test.go)
    - [language: example_with_tags_lang_test.go](/example_with_tags_lang_test.go)
@@ -47,7 +47,7 @@ go get -u github.com/bxcodec/faker/v3
  - Custom Struct's tag (define your own faker data): [example_custom_faker_test.go](/example_custom_faker_test.go)
  - Without struct's tag: [example_without_tag_test.go](/example_without_tag_test.go)
  - Single Fake Data Function: [example_single_fake_data_test.go](/example_single_fake_data_test.go)
- 
+
 ## DEMO
 
 ---
@@ -94,6 +94,7 @@ Unfortunately this library has some limitation
 * It does not support the `map[interface{}]interface{}`, `map[any_type]interface{}` & `map[interface{}]any_type` data types. Once again, we cannot generate values for an unknown data type.
 * Custom types are not fully supported. However some custom types are already supported: we are still investigating how to do this the correct way. For now, if you use `faker`, it's safer not to use any custom types in order to avoid panics.
 * Some extra custom types can be supported IF AND ONLY IF extended with [AddProvider()](https://github.com/bxcodec/faker/blob/9169c33ae9926e5b8f8732909790ee20b10b736a/faker.go#L320) please see [example](example_custom_faker_test.go#L46)
+* The `oneof` tag currently only supports `string` & `int`. Further support is coming soon. See [example](example_with_tags_test.go#L53) for usage.
 
 ## Contribution
 

--- a/example_custom_faker_test.go
+++ b/example_custom_faker_test.go
@@ -42,11 +42,7 @@ func CustomGenerator() {
 	})
 
 	_ = faker.AddProvider("customUUID", func(v reflect.Value) (interface{}, error) {
-<<<<<<< HEAD
 		s := CustomUUID{
-=======
-		s := []byte{
->>>>>>> origin/master
 			0, 8, 7, 2, 3,
 		}
 		return s, nil

--- a/example_custom_faker_test.go
+++ b/example_custom_faker_test.go
@@ -18,9 +18,9 @@ type CustomUUID []byte
 
 // Sample ...
 type Sample struct {
-	ID        int64     `faker:"customIdFaker"`
-	Gondoruwo Gondoruwo `faker:"gondoruwo"`
-	Danger    string    `faker:"danger"`
+	ID        int64      `faker:"customIdFaker"`
+	Gondoruwo Gondoruwo  `faker:"gondoruwo"`
+	Danger    string     `faker:"danger"`
 	UUID      CustomUUID `faker:"customUUID"`
 }
 
@@ -42,8 +42,8 @@ func CustomGenerator() {
 	})
 
 	_ = faker.AddProvider("customUUID", func(v reflect.Value) (interface{}, error) {
-		s := []byte {
-			0,8,7,2,3,
+		s := []byte{
+			0, 8, 7, 2, 3,
 		}
 		return s, nil
 	})

--- a/example_custom_faker_test.go
+++ b/example_custom_faker_test.go
@@ -42,7 +42,7 @@ func CustomGenerator() {
 	})
 
 	_ = faker.AddProvider("customUUID", func(v reflect.Value) (interface{}, error) {
-		s := []byte{
+		s := CustomUUID{
 			0, 8, 7, 2, 3,
 		}
 		return s, nil

--- a/example_with_tags_test.go
+++ b/example_with_tags_test.go
@@ -50,8 +50,8 @@ type SomeStructWithTags struct {
 	UUIDHypenated      string  `faker:"uuid_hyphenated"`
 	UUID               string  `faker:"uuid_digit"`
 	Skip               string  `faker:"-"`
-	PaymentMethod      string  `faker:"oneof:cc:paypal:check:money order"` // oneof will randomly pick one of the colon-separated values supplied in the tag
-	AccountID          int     `faker:"oneof:15:27:61"`                    // use colons to separate the values for now. Future support for other separator characters may be added
+	PaymentMethod      string  `faker:"oneof: cc, paypal, check, money order"` // oneof will randomly pick one of the comma-separated values supplied in the tag
+	AccountID          int     `faker:"oneof: 15, 27, 61"`                     // use commas to separate the values for now. Future support for other separator characters may be added
 }
 
 func Example_withTags() {

--- a/example_with_tags_test.go
+++ b/example_with_tags_test.go
@@ -50,6 +50,8 @@ type SomeStructWithTags struct {
 	UUIDHypenated      string  `faker:"uuid_hyphenated"`
 	UUID               string  `faker:"uuid_digit"`
 	Skip               string  `faker:"-"`
+	PaymentMethod      string  `faker:"oneof:cc:paypal:check:money order"`
+	AccountID          int     `faker:"oneof:15,27,61"`
 }
 
 func Example_withTags() {
@@ -104,6 +106,8 @@ func Example_withTags() {
 			AmountWithCurrency: XBB 49257.100000,
 			UUIDHypenated: 8f8e4463-9560-4a38-9b0c-ef24481e4e27,
 			UUID: 90ea6479fd0e4940af741f0a87596b73,
+			PaymentMethod: paypal,
+			AccountID: 61
 			Skip:
 		}
 	*/

--- a/example_with_tags_test.go
+++ b/example_with_tags_test.go
@@ -51,7 +51,7 @@ type SomeStructWithTags struct {
 	UUID               string  `faker:"uuid_digit"`
 	Skip               string  `faker:"-"`
 	PaymentMethod      string  `faker:"oneof:cc:paypal:check:money order"` // support for oneof tag
-	AccountID          int     `faker:"oneof:15,27,61"`                    // support for oneof tag
+	AccountID          int     `faker:"oneof:15:27:61"`                    // support for oneof tag
 }
 
 func Example_withTags() {

--- a/example_with_tags_test.go
+++ b/example_with_tags_test.go
@@ -50,8 +50,8 @@ type SomeStructWithTags struct {
 	UUIDHypenated      string  `faker:"uuid_hyphenated"`
 	UUID               string  `faker:"uuid_digit"`
 	Skip               string  `faker:"-"`
-	PaymentMethod      string  `faker:"oneof:cc:paypal:check:money order"`
-	AccountID          int     `faker:"oneof:15,27,61"`
+	PaymentMethod      string  `faker:"oneof:cc:paypal:check:money order"` // support for oneof tag
+	AccountID          int     `faker:"oneof:15,27,61"`                    // support for oneof tag
 }
 
 func Example_withTags() {

--- a/example_with_tags_test.go
+++ b/example_with_tags_test.go
@@ -50,8 +50,8 @@ type SomeStructWithTags struct {
 	UUIDHypenated      string  `faker:"uuid_hyphenated"`
 	UUID               string  `faker:"uuid_digit"`
 	Skip               string  `faker:"-"`
-	PaymentMethod      string  `faker:"oneof:cc:paypal:check:money order"` // support for oneof tag
-	AccountID          int     `faker:"oneof:15:27:61"`                    // support for oneof tag
+	PaymentMethod      string  `faker:"oneof:cc:paypal:check:money order"` // oneof will randomly pick one of the colon-separated values supplied in the tag
+	AccountID          int     `faker:"oneof:15:27:61"`                    // use colons to separate the values for now. Future support for other separator characters may be added
 }
 
 func Example_withTags() {

--- a/faker.go
+++ b/faker.go
@@ -113,8 +113,8 @@ const (
 	Equals                = "="
 	comma                 = ","
 	colon                 = ":"
-	period                = "."
 	ONEOF                 = "oneof"
+	// period                = "."
 )
 
 var defaultTag = map[string]string{

--- a/faker.go
+++ b/faker.go
@@ -771,7 +771,8 @@ func extractStringFromTag(tag string) (interface{}, error) {
 	var err error
 	strlen := randomStringLen
 	strlng := &lang
-	if !strings.Contains(tag, Length) && !strings.Contains(tag, Language) && !strings.Contains(tag, ONEOF) {
+	isOneOfTag := strings.Contains(tag, ONEOF)
+	if !strings.Contains(tag, Length) && !strings.Contains(tag, Language) && !isOneOfTag {
 		return nil, fmt.Errorf(ErrTagNotSupported, tag)
 	}
 	if strings.Contains(tag, Length) {
@@ -787,7 +788,7 @@ func extractStringFromTag(tag string) (interface{}, error) {
 			return nil, fmt.Errorf(ErrWrongFormattedTag, tag)
 		}
 	}
-	if strings.Contains(tag, ONEOF) {
+	if isOneOfTag {
 		items := strings.Split(tag, colon)
 		choose := items[1:]
 		toRet := choose[rand.Intn(len(choose))]

--- a/faker.go
+++ b/faker.go
@@ -622,21 +622,6 @@ func setDataWithTag(v reflect.Value, tag string) error {
 		reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Float32, reflect.Float64:
 		return userDefinedNumber(v, tag)
 	case reflect.Slice, reflect.Array:
-		/**
-		 * check for added Provider tag first before
-		 * defaulting to userDefinedArray()
-		 * this way the user at least has the
-		 * option of a custom tag working
-		 */
-		_, tagExists := mapperTag[tag]
-		if tagExists {
-			res, err := mapperTag[tag](v)
-			if err != nil {
-				return err
-			}
-			v.Set(reflect.ValueOf(res))
-			return nil
-		}
 		return userDefinedArray(v, tag)
 	case reflect.Map:
 		return userDefinedMap(v, tag)
@@ -706,6 +691,15 @@ func getValueWithTag(t reflect.Type, tag string) (interface{}, error) {
 }
 
 func userDefinedArray(v reflect.Value, tag string) error {
+	_, tagExists := mapperTag[tag]
+	if tagExists {
+		res, err := mapperTag[tag](v)
+		if err != nil {
+			return err
+		}
+		v.Set(reflect.ValueOf(res))
+		return nil
+	}
 	len := randomSliceAndMapSize()
 	if shouldSetNil && len == 0 {
 		v.Set(reflect.Zero(v.Type()))

--- a/faker.go
+++ b/faker.go
@@ -113,6 +113,7 @@ const (
 	Equals                = "="
 	comma                 = ","
 	colon                 = ":"
+	period                = "."
 	ONEOF                 = "oneof"
 )
 

--- a/faker.go
+++ b/faker.go
@@ -794,7 +794,7 @@ func extractStringFromTag(tag string) (interface{}, error) {
 		if len(toRet) <= 1 || strings.Contains(tag, comma) {
 			return nil, fmt.Errorf(ErrUnsupportedTagArguments)
 		}
-		return toRet, nil
+		return strings.TrimSpace(toRet), nil
 	}
 	res := randomString(strlen, strlng)
 	return res, nil
@@ -836,7 +836,7 @@ func extractNumberFromTag(tag string, t reflect.Type) (interface{}, error) {
 		}
 		var numberValues []int
 		for _, i := range values {
-			j, err := strconv.Atoi(i)
+			j, err := strconv.Atoi(strings.TrimSpace(i))
 			if err != nil {
 				return nil, fmt.Errorf(ErrUnsupportedTagArguments)
 			}

--- a/faker.go
+++ b/faker.go
@@ -806,9 +806,6 @@ func extractStringFromTag(tag string) (interface{}, error) {
 	}
 	if isOneOfTag {
 		items := strings.Split(tag, colon)
-		if len(items) <= 1 {
-			return nil, fmt.Errorf(ErrUnsupportedTagArguments)
-		}
 		argsList := items[1:]
 		if len(argsList) != 1 {
 			return nil, fmt.Errorf(ErrUnsupportedTagArguments)

--- a/faker.go
+++ b/faker.go
@@ -787,7 +787,11 @@ func extractStringFromTag(tag string) (interface{}, error) {
 	if strings.Contains(tag, ONEOF) {
 		items := strings.Split(tag, ":")
 		choose := items[1:]
-		return choose[rand.Intn(len(choose))], nil
+		toRet := choose[rand.Intn(len(choose))]
+		if len(toRet) <= 1 {
+			return nil, fmt.Errorf(ErrWrongFormattedTag, tag)
+		}
+		return toRet, nil
 	}
 	res := randomString(strlen, strlng)
 	return res, nil

--- a/faker.go
+++ b/faker.go
@@ -112,6 +112,7 @@ const (
 	BoundaryEnd           = "boundary_end"
 	Equals                = "="
 	comma                 = ","
+	ONEOF                 = "oneof"
 )
 
 var defaultTag = map[string]string{
@@ -767,7 +768,7 @@ func extractStringFromTag(tag string) (interface{}, error) {
 	var err error
 	strlen := randomStringLen
 	strlng := &lang
-	if !strings.Contains(tag, Length) && !strings.Contains(tag, Language) {
+	if !strings.Contains(tag, Length) && !strings.Contains(tag, Language) && !strings.Contains(tag, ONEOF) {
 		return nil, fmt.Errorf(ErrTagNotSupported, tag)
 	}
 	if strings.Contains(tag, Length) {
@@ -782,6 +783,11 @@ func extractStringFromTag(tag string) (interface{}, error) {
 		if err != nil {
 			return nil, fmt.Errorf(ErrWrongFormattedTag, tag)
 		}
+	}
+	if strings.Contains(tag, ONEOF) {
+		items := strings.Split(tag, ":")
+		choose := items[1:]
+		return choose[rand.Intn(len(choose))], nil
 	}
 	res := randomString(strlen, strlng)
 	return res, nil

--- a/faker_test.go
+++ b/faker_test.go
@@ -1256,12 +1256,12 @@ func TestUniqueFailure(t *testing.T) {
 
 func TestOneOfTag(t *testing.T) {
 
-	type CustomOne struct {
-		PaymentType string `faker:"oneof:credit card:paypal"`
+	type CustomOneString struct {
+		PaymentType string `faker:"oneof: credit card, paypal"`
 	}
 
-	t.Run("creates only one of the desired values", func(t *testing.T) {
-		a := CustomOne{}
+	t.Run("creates one of the desired string values", func(t *testing.T) {
+		a := CustomOneString{}
 		err := FakeData(&a)
 		if err != nil {
 			t.Errorf("expected no error, but got %v", err)
@@ -1279,11 +1279,11 @@ func TestOneOfTag(t *testing.T) {
 		}
 	})
 
-	type CustomMulti struct {
-		PaymentType string `faker:"oneof: cc: check: paypal: bank account"`
+	type CustomMultiString struct {
+		PaymentType string `faker:"oneof: cc, check, paypal, bank account"`
 	}
-	t.Run("creates only one of the desired values from many", func(t *testing.T) {
-		a := CustomMulti{}
+	t.Run("creates only one of the desired string values from many", func(t *testing.T) {
+		a := CustomMultiString{}
 		err := FakeData(&a)
 		if err != nil {
 			t.Errorf("expected no error, but got %v", err)
@@ -1305,12 +1305,29 @@ func TestOneOfTag(t *testing.T) {
 		}
 	})
 
-	type CustomOneofWrong struct {
+	type CustomOneofWrongString struct {
 		PaymentType string `faker:"oneof:"`
 	}
 
 	t.Run("errors when tag is not used correctly string no args", func(t *testing.T) {
-		a := CustomOneofWrong{}
+		a := CustomOneofWrongString{}
+		err := FakeData(&a)
+		if err == nil {
+			t.Errorf("expected error, but got no error")
+		}
+		actual := err.Error()
+		expected := ErrNotEnoughTagArguments
+		if actual != expected {
+			t.Errorf("expected %v, but got %v", expected, actual)
+		}
+	})
+
+	type CustomOneofWrongString2 struct {
+		PaymentType string `faker:"oneof: cc: check, bank"`
+	}
+
+	t.Run("errors when tag is not used correctly string invalid argument separator", func(t *testing.T) {
+		a := CustomOneofWrongString2{}
 		err := FakeData(&a)
 		if err == nil {
 			t.Errorf("expected error, but got no error")
@@ -1322,28 +1339,45 @@ func TestOneOfTag(t *testing.T) {
 		}
 	})
 
-	type CustomOneofWrong2 struct {
-		PaymentType string `faker:"oneof:cc:check,bank"`
+	type CustomWrongString3 struct {
+		PaymentType string `faker:"oneof: credit card"`
 	}
 
-	t.Run("errors when tag is not used correctly string bad args", func(t *testing.T) {
-		a := CustomOneofWrong2{}
+	t.Run("errors when tag is not used correctly string only one argument", func(t *testing.T) {
+		a := CustomWrongString3{}
 		err := FakeData(&a)
 		if err == nil {
 			t.Errorf("expected error, but got no error")
 		}
 		actual := err.Error()
-		expected := ErrUnsupportedTagArguments
+		expected := ErrNotEnoughTagArguments
+		if actual != expected {
+			t.Errorf("expected %v, but got %v", expected, actual)
+		}
+	})
+
+	type CustomWrongString4 struct {
+		PaymentType string `faker:"oneof: ,,,cc, credit card,,"`
+	}
+
+	t.Run("errors when tag is not used correctly string duplicate separator", func(t *testing.T) {
+		a := CustomWrongString4{}
+		err := FakeData(&a)
+		if err == nil {
+			t.Errorf("expected error, but got no error")
+		}
+		actual := err.Error()
+		expected := ErrDuplicateSeparator
 		if actual != expected {
 			t.Errorf("expected %v, but got %v", expected, actual)
 		}
 	})
 
 	type CustomOneofInt1 struct {
-		Age int `faker:"oneof: 16: 18: 21"`
+		Age int `faker:"oneof: 16, 18, 21"`
 	}
 
-	t.Run("should pick one of the numbers", func(t *testing.T) {
+	t.Run("should pick one of the number args", func(t *testing.T) {
 		a := CustomOneofInt1{}
 		err := FakeData(&a)
 		if err != nil {
@@ -1372,17 +1406,17 @@ func TestOneOfTag(t *testing.T) {
 			t.Errorf("expected error, but got no error")
 		}
 		actual := err.Error()
-		expected := ErrUnsupportedTagArguments
+		expected := ErrNotEnoughTagArguments
 		if actual != expected {
 			t.Errorf("expected %v, but got %v", expected, actual)
 		}
 	})
 
 	type CustomOneofWrongInt2 struct {
-		Age int `faker:"oneof:15:18,35"`
+		Age int `faker:"oneof: 15: 18, 35"`
 	}
 
-	t.Run("errors when tag is not used correctly bad args int", func(t *testing.T) {
+	t.Run("errors when tag is not used correctly int invalid argument separator", func(t *testing.T) {
 		a := CustomOneofWrongInt2{}
 		err := FakeData(&a)
 		if err == nil {
@@ -1396,10 +1430,10 @@ func TestOneOfTag(t *testing.T) {
 	})
 
 	type CustomOneofWrongInt3 struct {
-		Age int `faker:"oneof:15:18:oops"`
+		Age int `faker:"oneof: 15, 18, oops"`
 	}
 
-	t.Run("errors when tag is not used correctly mixed args int", func(t *testing.T) {
+	t.Run("errors when tag is not used correctly int invalid argument type", func(t *testing.T) {
 		a := CustomOneofWrongInt3{}
 		err := FakeData(&a)
 		if err == nil {
@@ -1407,6 +1441,40 @@ func TestOneOfTag(t *testing.T) {
 		}
 		actual := err.Error()
 		expected := ErrUnsupportedTagArguments
+		if actual != expected {
+			t.Errorf("expected %v, but got %v", expected, actual)
+		}
+	})
+
+	type CustomWrongInt4 struct {
+		Age int `faker:"oneof: 15"`
+	}
+
+	t.Run("errors when tag is not used correctly int only one argument", func(t *testing.T) {
+		a := CustomWrongInt4{}
+		err := FakeData(&a)
+		if err == nil {
+			t.Fatal("expected error, but got no error")
+		}
+		actual := err.Error()
+		expected := ErrNotEnoughTagArguments
+		if actual != expected {
+			t.Errorf("expected %v, but got %v", expected, actual)
+		}
+	})
+
+	type CustomWrongInt5 struct {
+		Age int `faker:"oneof: 15,,16,17"`
+	}
+
+	t.Run("errors when tag is not used correctly int only one argument", func(t *testing.T) {
+		a := CustomWrongInt5{}
+		err := FakeData(&a)
+		if err == nil {
+			t.Fatal("expected error, but got no error")
+		}
+		actual := err.Error()
+		expected := ErrDuplicateSeparator
 		if actual != expected {
 			t.Errorf("expected %v, but got %v", expected, actual)
 		}

--- a/faker_test.go
+++ b/faker_test.go
@@ -1275,6 +1275,50 @@ func TestOneOfTag(t *testing.T) {
 			)
 		}
 	})
+
+	type CustomMulti struct {
+		PaymentType string `faker:"oneof:cc:check:paypal:bank account"`
+	}
+	t.Run("creates only one of the desired values from many", func(t *testing.T) {
+		a := CustomMulti{}
+		err := FakeData(&a)
+		if err != nil {
+			t.Errorf("expected no error, but got %v", err)
+		}
+		one := a.PaymentType == "cc"
+		two := a.PaymentType == "paypal"
+		three := a.PaymentType == "check"
+		four := a.PaymentType == "bank account"
+
+		if !one && !two && !three && !four {
+			t.Errorf(
+				"expected either %v or %v or %v or %v but got %v",
+				"cc",
+				"paypal",
+				"check",
+				"bank account",
+				a.PaymentType,
+			)
+		}
+	})
+
+	type CustomOneofWrong struct {
+		PaymentType string `faker:"oneof:"`
+	}
+
+	t.Run("errors when tag is not used correctly", func(t *testing.T) {
+		a := CustomOneofWrong{}
+		err := FakeData(&a)
+		if err == nil {
+			t.Errorf("expected error, but got no error")
+		}
+		actual := err.Error()
+		expected := fmt.Sprintf(ErrWrongFormattedTag, "oneof:")
+		if actual != expected {
+			t.Errorf("expected %v, but got %v", expected, actual)
+		}
+	})
+
 }
 
 // getStringLen for language independent string length

--- a/faker_test.go
+++ b/faker_test.go
@@ -1306,14 +1306,104 @@ func TestOneOfTag(t *testing.T) {
 		PaymentType string `faker:"oneof:"`
 	}
 
-	t.Run("errors when tag is not used correctly", func(t *testing.T) {
+	t.Run("errors when tag is not used correctly string no args", func(t *testing.T) {
 		a := CustomOneofWrong{}
 		err := FakeData(&a)
 		if err == nil {
 			t.Errorf("expected error, but got no error")
 		}
 		actual := err.Error()
-		expected := fmt.Sprintf(ErrWrongFormattedTag, "oneof:")
+		expected := fmt.Sprintf(ErrUnsupportedTagArguments)
+		if actual != expected {
+			t.Errorf("expected %v, but got %v", expected, actual)
+		}
+	})
+
+	type CustomOneofWrong2 struct {
+		PaymentType string `faker:"oneof:cc:check,bank"`
+	}
+
+	t.Run("errors when tag is not used correctly string bad args", func(t *testing.T) {
+		a := CustomOneofWrong2{}
+		err := FakeData(&a)
+		if err == nil {
+			t.Errorf("expected error, but got no error")
+		}
+		actual := err.Error()
+		expected := fmt.Sprintf(ErrUnsupportedTagArguments)
+		if actual != expected {
+			t.Errorf("expected %v, but got %v", expected, actual)
+		}
+	})
+
+	type CustomOneofInt1 struct {
+		Age int `faker:"oneof:16:18:21"`
+	}
+
+	t.Run("should pick one of the numbers", func(t *testing.T) {
+		a := CustomOneofInt1{}
+		err := FakeData(&a)
+		if err != nil {
+			t.Errorf("expected no error, but got %v", err)
+		}
+		one := a.Age == 16
+		two := a.Age == 18
+		three := a.Age == 21
+		actual := a.Age
+		if !one && !two && !three {
+			t.Errorf(
+				"expected either %v, %v, or %v, but got %v",
+				16, 18, 21, actual,
+			)
+		}
+	})
+
+	type CustomOneofWrongInt struct {
+		Age int `faker:"oneof:"`
+	}
+
+	t.Run("errors when tag is not used correctly no args int", func(t *testing.T) {
+		a := CustomOneofWrongInt{}
+		err := FakeData(&a)
+		if err == nil {
+			t.Errorf("expected error, but got no error")
+		}
+		actual := err.Error()
+		expected := fmt.Sprintf(ErrUnsupportedTagArguments)
+		if actual != expected {
+			t.Errorf("expected %v, but got %v", expected, actual)
+		}
+	})
+
+	type CustomOneofWrongInt2 struct {
+		Age int `faker:"oneof:15:18,35"`
+	}
+
+	t.Run("errors when tag is not used correctly bad args int", func(t *testing.T) {
+		a := CustomOneofWrongInt2{}
+		err := FakeData(&a)
+		if err == nil {
+			t.Errorf("expected error, but got no error")
+		}
+		actual := err.Error()
+		expected := fmt.Sprintf(ErrUnsupportedTagArguments)
+		if actual != expected {
+			t.Errorf("expected %v, but got %v", expected, actual)
+		}
+	})
+
+	type CustomOneofWrongInt3 struct {
+		Age int `faker:"oneof:15:18:oops"`
+	}
+
+	t.Run("errors when tag is not used correctly mixed args int", func(t *testing.T) {
+		a := CustomOneofWrongInt3{}
+		err := FakeData(&a)
+		if err == nil {
+			t.Fatal("expected error, but got no error")
+		}
+		actual := err.Error()
+		expected := fmt.Sprintf(ErrUnsupportedTagArguments)
 		if actual != expected {
 			t.Errorf("expected %v, but got %v", expected, actual)
 		}

--- a/faker_test.go
+++ b/faker_test.go
@@ -1277,7 +1277,7 @@ func TestOneOfTag(t *testing.T) {
 	})
 
 	type CustomMulti struct {
-		PaymentType string `faker:"oneof:cc:check:paypal:bank account"`
+		PaymentType string `faker:"oneof: cc: check: paypal: bank account"`
 	}
 	t.Run("creates only one of the desired values from many", func(t *testing.T) {
 		a := CustomMulti{}
@@ -1337,7 +1337,7 @@ func TestOneOfTag(t *testing.T) {
 	})
 
 	type CustomOneofInt1 struct {
-		Age int `faker:"oneof:16:18:21"`
+		Age int `faker:"oneof: 16: 18: 21"`
 	}
 
 	t.Run("should pick one of the numbers", func(t *testing.T) {

--- a/faker_test.go
+++ b/faker_test.go
@@ -1313,7 +1313,7 @@ func TestOneOfTag(t *testing.T) {
 			t.Errorf("expected error, but got no error")
 		}
 		actual := err.Error()
-		expected := fmt.Sprintf(ErrUnsupportedTagArguments)
+		expected := ErrUnsupportedTagArguments
 		if actual != expected {
 			t.Errorf("expected %v, but got %v", expected, actual)
 		}
@@ -1330,7 +1330,7 @@ func TestOneOfTag(t *testing.T) {
 			t.Errorf("expected error, but got no error")
 		}
 		actual := err.Error()
-		expected := fmt.Sprintf(ErrUnsupportedTagArguments)
+		expected := ErrUnsupportedTagArguments
 		if actual != expected {
 			t.Errorf("expected %v, but got %v", expected, actual)
 		}
@@ -1369,7 +1369,7 @@ func TestOneOfTag(t *testing.T) {
 			t.Errorf("expected error, but got no error")
 		}
 		actual := err.Error()
-		expected := fmt.Sprintf(ErrUnsupportedTagArguments)
+		expected := ErrUnsupportedTagArguments
 		if actual != expected {
 			t.Errorf("expected %v, but got %v", expected, actual)
 		}
@@ -1386,7 +1386,7 @@ func TestOneOfTag(t *testing.T) {
 			t.Errorf("expected error, but got no error")
 		}
 		actual := err.Error()
-		expected := fmt.Sprintf(ErrUnsupportedTagArguments)
+		expected := ErrUnsupportedTagArguments
 		if actual != expected {
 			t.Errorf("expected %v, but got %v", expected, actual)
 		}
@@ -1403,7 +1403,7 @@ func TestOneOfTag(t *testing.T) {
 			t.Fatal("expected error, but got no error")
 		}
 		actual := err.Error()
-		expected := fmt.Sprintf(ErrUnsupportedTagArguments)
+		expected := ErrUnsupportedTagArguments
 		if actual != expected {
 			t.Errorf("expected %v, but got %v", expected, actual)
 		}

--- a/faker_test.go
+++ b/faker_test.go
@@ -969,7 +969,7 @@ func TestExtend(t *testing.T) {
 	t.Run("test-with-custom-slice-type", func(t *testing.T) {
 		a := CustomThatUsesSlice{}
 		err := AddProvider("custom-type-over-slice", func(v reflect.Value) (interface{}, error) {
-			return []byte{0, 1, 2, 3, 4}, nil
+			return CustomTypeOverSlice{0, 1, 2, 3, 4}, nil
 		})
 
 		if err != nil {

--- a/faker_test.go
+++ b/faker_test.go
@@ -150,7 +150,7 @@ func (s SomeStruct) String() string {
 	SFloat64:%v
 	SBool: %v
 	Struct: %v
-	Time: %v 
+	Time: %v
 	Stime: %v
 	Currency: %v
 	Amount: %v
@@ -159,7 +159,7 @@ func (s SomeStruct) String() string {
 	HyphenatedID: %v
 
 	MapStringString: %v
-	MapStringStruct: %v 
+	MapStringStruct: %v
 	MapStringStructPointer: %v
 	}`, s.Inta, s.Int8, s.Int16, s.Int32,
 		s.Int64, s.Float32, s.Float64, s.UInta,

--- a/faker_test.go
+++ b/faker_test.go
@@ -969,7 +969,7 @@ func TestExtend(t *testing.T) {
 	t.Run("test-with-custom-slice-type", func(t *testing.T) {
 		a := CustomThatUsesSlice{}
 		err := AddProvider("custom-type-over-slice", func(v reflect.Value) (interface{}, error) {
-			return []byte{0,1,2,3,4}, nil
+			return []byte{0, 1, 2, 3, 4}, nil
 		})
 
 		if err != nil {
@@ -982,14 +982,14 @@ func TestExtend(t *testing.T) {
 			t.Error("Expected Not Error, But Got: ", err)
 		}
 
-		if reflect.DeepEqual(a.UUID, []byte{0,1,2,3,4}) {
+		if reflect.DeepEqual(a.UUID, []byte{0, 1, 2, 3, 4}) {
 			t.Error("UUID should equal test value")
 		}
 	})
 
 	type MyInt int
 	type Sample struct {
-		Value  []MyInt `faker:"myint"`
+		Value []MyInt `faker:"myint"`
 	}
 
 	t.Run("test with type alias for int", func(t *testing.T) {
@@ -1249,6 +1249,32 @@ func TestUniqueFailure(t *testing.T) {
 	if !hasError {
 		t.Errorf("expected error, but got nil")
 	}
+}
+
+func TestOneOfTag(t *testing.T) {
+
+	type CustomOne struct {
+		PaymentType string `faker:"oneof:credit card:paypal"`
+	}
+
+	t.Run("creates only one of the desired values", func(t *testing.T) {
+		a := CustomOne{}
+		err := FakeData(&a)
+		if err != nil {
+			t.Errorf("expected no error, but got %v", err)
+		}
+		one := a.PaymentType == "credit card"
+		two := a.PaymentType == "paypal"
+
+		if !one && !two {
+			t.Errorf(
+				"expected either %v or %v but got %v",
+				"credit card",
+				"paypal",
+				a.PaymentType,
+			)
+		}
+	})
 }
 
 // getStringLen for language independent string length


### PR DESCRIPTION
- This adds support for a `faker:"oneof: val1 :val2 :val3"`
- Currently only `string` and `int` is suppported
- I would be happy to add support for more types at a later time
- This looks like it might fix (or at least partially fix) https://github.com/bxcodec/faker/issues/82