### PR TITLE
feat: Add RemoveProvider public method

### DIFF
--- a/faker.go
+++ b/faker.go
@@ -224,6 +224,7 @@ var mapperTag = map[string]TaggedFunction{
 // 		ErrValueNotPtr: Error when value is not pointer
 // 		ErrTagNotSupported: Error when tag is not supported
 // 		ErrTagAlreadyExists: Error when tag exists and call AddProvider
+// 		ErrTagDoesNotExist: Error when tag does not exist and call RemoveProvider
 // 		ErrMoreArguments: Error on passing more arguments
 // 		ErrNotSupportedPointer: Error when passing unsupported pointer
 var (
@@ -232,6 +233,7 @@ var (
 	ErrValueNotPtr         = "Not a pointer value"
 	ErrTagNotSupported     = "Tag unsupported: %s"
 	ErrTagAlreadyExists    = "Tag exists"
+	ErrTagDoesNotExist     = "Tag does not exist"
 	ErrMoreArguments       = "Passed more arguments than is possible : (%d)"
 	ErrNotSupportedPointer = "Use sample:=new(%s)\n faker.FakeData(sample) instead"
 	ErrSmallerThanZero     = "Size:%d is smaller than zero."
@@ -384,6 +386,17 @@ func AddProvider(tag string, provider TaggedFunction) error {
 	}
 
 	mapperTag[tag] = provider
+
+	return nil
+}
+
+// RemoveProvider removes existing customization added with AddProvider
+func RemoveProvider(tag string) error {
+	if _, ok := mapperTag[tag]; !ok {
+		return errors.New(ErrTagDoesNotExist)
+	}
+
+	delete(mapperTag, tag)
 
 	return nil
 }

--- a/faker_test.go
+++ b/faker_test.go
@@ -1090,6 +1090,25 @@ func TestTagAlreadyExists(t *testing.T) {
 	}
 }
 
+func TestRemoveProvider(t *testing.T) {
+	AddProvider("test", func(v reflect.Value) (interface{}, error) {
+		return "test", nil
+	})
+
+	err := RemoveProvider("test")
+	if err != nil {
+		t.Error("Expected Not Error, But Got: ", err)
+	}
+}
+
+func TestTagDoesNotExist(t *testing.T) {
+	err := RemoveProvider("not_existing_test_tag")
+
+	if err == nil || err.Error() != ErrTagDoesNotExist {
+		t.Error("Expected ErrTagDoesNotExist Error,  But Got: ", err)
+	}
+}
+
 func TestTagWithPointer(t *testing.T) {
 
 	type TestStruct struct {

--- a/faker_test.go
+++ b/faker_test.go
@@ -1091,11 +1091,14 @@ func TestTagAlreadyExists(t *testing.T) {
 }
 
 func TestRemoveProvider(t *testing.T) {
-	AddProvider("test", func(v reflect.Value) (interface{}, error) {
+	err := AddProvider("new_test_tag", func(v reflect.Value) (interface{}, error) {
 		return "test", nil
 	})
+	if err != nil {
+		t.Error("Expected Not Error, But Got: ", err)
+	}
 
-	err := RemoveProvider("test")
+	err = RemoveProvider("new_test_tag")
 	if err != nil {
 		t.Error("Expected Not Error, But Got: ", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/pioz/faker/v3
+module github.com/bxcodec/faker/v3
 
 go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/bxcodec/faker/v3
+module github.com/pioz/faker/v3
 
 go 1.12


### PR DESCRIPTION
This method removes existing customization added with AddProvider.
This can be useful if you need to reset your customization and add
a new one with the same name.