### PR TITLE
Fix typo on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Support Only For :
 ---
 
 Unfortunately this library has some limitation
-* It does not support private fields. Make sure your structs fields you intend to generate fake data for are public, it would otherwise trigger a panic. You can however omit fields using a tag skip `faker:"-"` on your private fields.
+* It does not support private fields. Make sure your structs fields you intend to generate fake data for are public, it would otherwise trigger a panic. You can however omit fields using a tag skip `faker:"-"` on your public fields.
 * It does not support the `interface{}` data type. How could we generate anything without knowing its data type?
 * It does not support the `map[interface{}]interface{}`, `map[any_type]interface{}` & `map[interface{}]any_type` data types. Once again, we cannot generate values for an unknown data type.
 * Custom types are not fully supported. However some custom types are already supported: we are still investigating how to do this the correct way. For now, if you use `faker`, it's safer not to use any custom types in order to avoid panics.


### PR DESCRIPTION
I believe this to be a typo, private fields can't "be skipped" because they can't be used anyway, so that option would be useful public fields only.