### PR TITLE
feat: Add ability to ignore interface{} population with SetIgnoreInterface()

### DIFF
--- a/faker.go
+++ b/faker.go
@@ -1092,12 +1092,16 @@ func randomString(n int, lang *langRuneBoundary) (string, error) {
 
 // randomIntegerWithBoundary returns a random integer between input start and end boundary. [start, end)
 func randomIntegerWithBoundary(boundary numberBoundary) int {
-	return rand.Intn(boundary.end-boundary.start) + boundary.start
+	span := boundary.end - boundary.start
+	if span <= 0 {
+		return boundary.start
+	}
+	return rand.Intn(span) + boundary.start
 }
 
 // randomInteger returns a random integer between start and end boundary. [start, end)
 func randomInteger() int {
-	return rand.Intn(nBoundary.end-nBoundary.start) + nBoundary.start
+	return randomIntegerWithBoundary(nBoundary)
 }
 
 // randomSliceAndMapSize returns a random integer between [0,randomSliceAndMapSize). If the testRandZero is set, returns 0

--- a/faker.go
+++ b/faker.go
@@ -30,6 +30,8 @@ var (
 	randomSize = 100
 	// Sets the single fake data generator to generate unique values
 	generateUniqueValues = false
+	// Sets whether interface{}s should be ignored.
+	ignoreInterface = false
 	// Unique values are kept in memory so the generator retries if the value already exists
 	uniqueValues = map[string][]interface{}{}
 	// Lang is selected language for random string generator
@@ -273,6 +275,11 @@ func SetGenerateUniqueValues(unique bool) {
 	generateUniqueValues = unique
 }
 
+// SetIgnoreInterface allows to set a flag to ignore found interface{}s.
+func SetIgnoreInterface(ignore bool) {
+	ignoreInterface = ignore
+}
+
 // SetNilIfLenIsZero allows to set nil for the slice and maps, if size is 0.
 func SetNilIfLenIsZero(setNil bool) {
 	shouldSetNil = setNil
@@ -391,6 +398,9 @@ func AddProvider(tag string, provider TaggedFunction) error {
 func getValue(a interface{}) (reflect.Value, error) {
 	t := reflect.TypeOf(a)
 	if t == nil {
+		if ignoreInterface {
+			return reflect.New(reflect.TypeOf(reflect.Struct)), nil
+		}
 		return reflect.Value{}, fmt.Errorf("interface{} not allowed")
 	}
 	k := t.Kind()

--- a/faker_test.go
+++ b/faker_test.go
@@ -480,6 +480,19 @@ func TestSetNilIfLenIsZero(t *testing.T) {
 	testRandZero = false
 }
 
+func TestSetIgnoreInterface(t *testing.T) {
+	SetIgnoreInterface(false)
+	var someInterface interface{}
+	if err := FakeData(&someInterface); err == nil {
+		t.Error("Fake data generation didn't fail on interface{}")
+	}
+	SetIgnoreInterface(true)
+	if err := FakeData(&someInterface); err != nil {
+		t.Error("Fake data generation fail on interface{} with SetIgnoreInterface(true)")
+	}
+	SetIgnoreInterface(false)
+}
+
 func TestBoundaryAndLen(t *testing.T) {
 	iterate := 10
 	someStruct := SomeStructWithLen{}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/bxcodec/faker/v3
+module github.com/irridia/faker
 
-go 1.12
+go 1.15

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/irridia/faker
+module github.com/bxcodec/faker/v3
 
-go 1.15
+go 1.12


### PR DESCRIPTION
This PR adds a flag that tells faker to ignore the population of interface{} types.

This is useful when populating complex structures for Marshal testing, where you don't have the control or ability to use a non-interface{}. This makes testing complex structure marshaling a LOT simpler, since otherwise you would have to faker every element in the structure above and beside an interface{}.

The default behavior is to not ignore interface{}, so no behavior changes should be seen.

A test has been added.

Thanks!