### PR TITLE
Added min and max in slice and map size

### DIFF
--- a/example_with_tags_lenbounds_test.go
+++ b/example_with_tags_lenbounds_test.go
@@ -28,7 +28,7 @@ func Example_withTagsLengthAndBoundary() {
 		MIint    map[int]int       `faker:"boundary_start=5, boundary_end=10"`
 	}
 
-	_ = faker.SetRandomMapAndSliceSize(20) // Random generated map or array size wont exceed 20...
+	_ = faker.SetRandomMapAndSliceSize(1, 20) // Random generated map or array size wont exceed 20...
 	a := SomeStruct{}
 	_ = faker.FakeData(&a)
 	fmt.Printf("%+v", a)

--- a/example_with_tags_slicelength_test.go
+++ b/example_with_tags_slicelength_test.go
@@ -13,23 +13,23 @@ func Example_withTagsSliceLength() {
 		EmptyList       []string `faker:"slice_len=0"`
 		FixedStringList []string `faker:"slice_len=2"`
 		FixedIntList    []int64  `faker:"slice_len=4"`
-		RandomIntList    []int64
+		RandomIntList   []int64
 	}
 
-	_ = faker.SetRandomMapAndSliceSize(20) // If no slice_len is set, this sets the max of the random size
+	_ = faker.SetRandomMapAndSliceSize(1, 20) // If no slice_len is set, this sets the max of the random size
 	a := SomeStruct{}
 	_ = faker.FakeData(&a)
 	fmt.Printf("%+v", a)
 	// Result:
 	/*
-	   {
-	       EmptyList:[]
-	       FixedStringList:[
-		           geHYIpEoQhQdijFooVEAOyvtTwJOofbQPJdbHvEEdjueZaKIgI
-		           WVJBBtmrrVccyIydAiLSkMwWbFzFMEotEXsyUXqcmBTVORlkJK
-		   ]
-		   FixedIntList:[10,25,60,15]
-	       RandomIntList:[5,16,134,6235,123,53,123] //Random len() with a max of 20
-	   }
+		{
+				EmptyList:[]
+				FixedStringList:[
+							geHYIpEoQhQdijFooVEAOyvtTwJOofbQPJdbHvEEdjueZaKIgI
+							WVJBBtmrrVccyIydAiLSkMwWbFzFMEotEXsyUXqcmBTVORlkJK
+			]
+			FixedIntList:[10,25,60,15]
+				RandomIntList:[5,16,134,6235,123,53,123] //Random len() with a max of 20
+		}
 	*/
 }

--- a/faker.go
+++ b/faker.go
@@ -27,7 +27,7 @@ var (
 	//Sets the boundary for random value generation. Boundaries can not exceed integer(4 byte...)
 	nBoundary = numberBoundary{start: 0, end: 100}
 	//Sets the random size for slices and maps.
-	randomSize = 100
+	randomSize = numberBoundary{start: 0, end: 100}
 	// Sets the single fake data generator to generate unique values
 	generateUniqueValues = false
 	// Sets whether interface{}s should be ignored.
@@ -305,11 +305,14 @@ func SetStringLang(l langRuneBoundary) {
 }
 
 // SetRandomMapAndSliceSize sets the size for maps and slices for random generation.
-func SetRandomMapAndSliceSize(size int) error {
-	if size < 1 {
-		return fmt.Errorf(ErrSmallerThanOne, size)
+func SetRandomMapAndSliceSize(start, end int) error {
+	if start > end {
+		return errors.New(ErrStartValueBiggerThanEnd)
 	}
-	randomSize = size
+	if start < 1 {
+		return fmt.Errorf(ErrSmallerThanOne, start)
+	}
+	randomSize = numberBoundary{start: start, end: end}
 	return nil
 }
 
@@ -1126,7 +1129,7 @@ func randomSliceAndMapSize() int {
 	if testRandZero {
 		return 0
 	}
-	return rand.Intn(randomSize)
+	return randomIntegerWithBoundary(nBoundary)
 }
 
 func randomElementFromSliceString(s []string) string {

--- a/faker_test.go
+++ b/faker_test.go
@@ -450,11 +450,11 @@ func TestSetRandomNumberBoundaries(t *testing.T) {
 
 func TestSetRandomMapAndSliceSize(t *testing.T) {
 	someStruct := SomeStruct{}
-	if err := SetRandomMapAndSliceSize(-1); err == nil {
+	if err := SetRandomMapAndSliceSize(0, -1); err == nil {
 		t.Error("Random Map and Slice must not accept lower than 0 as a size")
 	}
 	size := 5
-	if err := SetRandomMapAndSliceSize(size); err != nil {
+	if err := SetRandomMapAndSliceSize(1, size); err != nil {
 		t.Error("SetRandomMapAndSliceSize method is corrupted.")
 	}
 	if err := FakeData(&someStruct); err != nil {


### PR DESCRIPTION
I am facing a use case where I need to fill a struct with some data where all the fields are populated, but the serialized data is as small as possible. I can set the min and max string size to 1, min and max value of int to 1, but cannot set the min and max length of slices and maps to 1.

This PR makes the necessary changes to allow users to set the minimum size of slices and maps too.