### PR TITLE
Support for Emoticons

### DIFF
--- a/example_with_tags_lang_test.go
+++ b/example_with_tags_lang_test.go
@@ -29,7 +29,7 @@ func Example_withTagsLang() {
 			   StringCHI: 随机字符串
 			   StringRUS:ваЩфз
 			   StringJPN:びゃほぱヒてふ
-			   StringKOR:텻밚쨋큊몉\
+			   StringKOR:텻밚쨋큊몉
 			   StringEMJ:🐅😄🕢🍪🐡
 		   }
 	*/

--- a/example_with_tags_lang_test.go
+++ b/example_with_tags_lang_test.go
@@ -14,6 +14,7 @@ func Example_withTagsLang() {
 		StringCHI string `faker:"lang=chi"`
 		StringRUS string `faker:"lang=rus"`
 		StringJPN string `faker:"lang=jpn"`
+		StringEMJ string `faker:"lang=emj"`
 	}
 
 	a := SomeStruct{}
@@ -27,6 +28,7 @@ func Example_withTagsLang() {
 			   StringCHI: 随机字符串
 			   StringRUS:ваЩфз
 			   StringJPN:びゃほぱヒてふ
+			   StringEMJ:🐅😄🕢🍪🐡
 		   }
 	*/
 }

--- a/faker.go
+++ b/faker.go
@@ -64,6 +64,8 @@ var (
 	LangRUS = langRuneBoundary{1025, 1105, nil}
 	// LangJPN is for japanese Hiragana Katakana language
 	LangJPN = langRuneBoundary{12353, 12534, []rune{12436, 12437, 12438, 12439, 12440, 12441, 12442, 12443, 12444, 12445, 12446, 12447, 12448}}
+	// EmotEMJ is for emoticons
+	EmotEMJ = langRuneBoundary{126976, 129535, nil}
 )
 
 // Supported tags
@@ -310,7 +312,7 @@ func SetRandomStringLength(size int) error {
 	return nil
 }
 
-// SetStringLang sets language of random string generation (LangENG, LangCHI, LangRUS, LangJPN)
+// SetStringLang sets language of random string generation (LangENG, LangCHI, LangRUS, LangJPN, EmotEMJ)
 func SetStringLang(l langRuneBoundary) {
 	lang = l
 }
@@ -916,6 +918,8 @@ func extractLangFromTag(tag string) (*langRuneBoundary, error) {
 		return &LangCHI, nil
 	case "jpn":
 		return &LangJPN, nil
+	case "emj":
+		return &EmotEMJ, nil
 	default:
 		return &LangENG, nil
 	}

--- a/faker_test.go
+++ b/faker_test.go
@@ -19,10 +19,11 @@ const (
 	someStructWithLenAndLangCHI = 10
 	someStructWithLenAndLangRUS = 15
 	someStructWithLenAndLangJPN = 20
+	someStructWithLenAndEmotEMJ = 50
 )
 
 var (
-	langCorrectTagsMap = map[string]langRuneBoundary{"lang=eng": LangENG, "lang=chi": LangCHI, "lang=rus": LangRUS, "lang=jpn": LangJPN}
+	langCorrectTagsMap = map[string]langRuneBoundary{"lang=eng": LangENG, "lang=chi": LangCHI, "lang=rus": LangRUS, "lang=jpn": LangJPN, "lang=emj": EmotEMJ}
 	langUncorrectTags  = [3]string{"lang=", "lang", "lng=eng"}
 
 	lenCorrectTags   = [3]string{"len=4", "len=5", "len=10"}
@@ -112,6 +113,7 @@ type SomeStructWithLang struct {
 	ValueCHI string `faker:"lang=chi"`
 	ValueRUS string `faker:"lang=rus"`
 	ValueJPN string `faker:"lang=jpn"`
+	ValueEMJ string `faker:"lang=emj"`
 
 	ValueWithUndefinedLang string `faker:"lang=und"`
 }
@@ -121,6 +123,7 @@ type SomeStructWithLenAndLang struct {
 	ValueCHI string ` faker:"len=10, lang=chi"`
 	ValueRUS string ` faker:"len=15, lang=rus"`
 	ValueJPN string ` faker:"len=20, lang=jpn"`
+	ValueEMJ string ` faker:"len=50, lang=emj"`
 }
 
 func (s SomeStruct) String() string {
@@ -595,6 +598,10 @@ func TestLang(t *testing.T) {
 	if err != nil {
 		t.Error(err.Error())
 	}
+	err = isStringLangCorrect(someStruct.ValueEMJ, EmotEMJ)
+	if err != nil {
+		t.Error(err.Error())
+	}
 
 	err = isStringLangCorrect(someStruct.ValueWithUndefinedLang, LangENG)
 	if err != nil {
@@ -736,6 +743,15 @@ func TestLangWithLen(t *testing.T) {
 	jpnLen := utfLen(someStruct.ValueJPN)
 	if jpnLen != someStructWithLenAndLangJPN {
 		t.Errorf("Got %d, but expected to be %d as a string len", jpnLen, someStructWithLenAndLangJPN)
+	}
+
+	err = isStringLangCorrect(someStruct.ValueEMJ, EmotEMJ)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	emjLen := utfLen(someStruct.ValueEMJ)
+	if emjLen != someStructWithLenAndEmotEMJ {
+		t.Errorf("Got %d, but expected to be %d as a string len", emjLen, someStructWithLenAndEmotEMJ)
 	}
 }
 


### PR DESCRIPTION
Support for Emoticons
But still using `lang` tag

Usage:
```go
StringEMJ string `faker:"lang=emj"`
```

Output:
```
StringEMJ:🐅😄🕢🍪🐡
```
			   