### PR TITLE
Float boundaries

### DIFF
--- a/example_with_tags_lenbounds_test.go
+++ b/example_with_tags_lenbounds_test.go
@@ -22,6 +22,9 @@ func Example_withTagsLengthAndBoundary() {
 		UInt32 uint32 `faker:"boundary_start=0, boundary_end=40"`
 		UInt64 uint64 `faker:"boundary_start=14, boundary_end=50"`
 
+		Float32 float32 `faker:"boundary_start=12.65, boundary_end=184.05"`
+		Float64 float64 `faker:"boundary_start=1.256, boundary_end=3.4"`
+
 		ASString []string          `faker:"len=50"`
 		SString  string            `faker:"len=25"`
 		MSString map[string]string `faker:"len=30"`
@@ -45,6 +48,8 @@ func Example_withTagsLengthAndBoundary() {
 	       UInt16:1797
 	       UInt32:8
 	       UInt64:34
+	       Float32:60.999058
+	       Float64:2.590148738554016
 	       ASString:[
 	           geHYIpEoQhQdijFooVEAOyvtTwJOofbQPJdbHvEEdjueZaKIgI
 	           WVJBBtmrrVccyIydAiLSkMwWbFzFMEotEXsyUXqcmBTVORlkJK

--- a/faker_test.go
+++ b/faker_test.go
@@ -130,6 +130,9 @@ type SomeStructWithLen struct {
 	UInt32 uint32 `faker:"boundary_start=5, boundary_end=10"`
 	UInt64 uint64 `faker:"boundary_start=5, boundary_end=10"`
 
+	Float32 float32 `faker:"boundary_start=5, boundary_end=10"`
+	Float64 float64 `faker:"boundary_start=5, boundary_end=10"`
+
 	ASString []string          `faker:"len=2"`
 	SString  string            `faker:"len=2"`
 	MSString map[string]string `faker:"len=2"`
@@ -482,7 +485,7 @@ func TestSetRandomNumberBoundaries(t *testing.T) {
 	if err := SetRandomNumberBoundaries(10, 0); err == nil {
 		t.Error("Start must be smaller than end value")
 	}
-	boundary := numberBoundary{start: 10, end: 90}
+	boundary := intBoundary{start: 10, end: 90}
 	if err := SetRandomNumberBoundaries(boundary.start, boundary.end); err != nil {
 		t.Error("SetRandomNumberBoundaries method is corrupted.")
 	}
@@ -548,34 +551,40 @@ func TestBoundaryAndLen(t *testing.T) {
 		if err := FakeData(&someStruct); err != nil {
 			t.Error(err)
 		}
-		if err := validateRange(int(someStruct.Int8)); err != nil {
+		if err := validateIntRange(int(someStruct.Int8)); err != nil {
 			t.Error(err)
 		}
-		if err := validateRange(int(someStruct.Int16)); err != nil {
+		if err := validateIntRange(int(someStruct.Int16)); err != nil {
 			t.Error(err)
 		}
-		if err := validateRange(int(someStruct.Int32)); err != nil {
+		if err := validateIntRange(int(someStruct.Int32)); err != nil {
 			t.Error(err)
 		}
-		if err := validateRange(someStruct.Inta); err != nil {
+		if err := validateIntRange(someStruct.Inta); err != nil {
 			t.Error(err)
 		}
-		if err := validateRange(int(someStruct.Int64)); err != nil {
+		if err := validateIntRange(int(someStruct.Int64)); err != nil {
 			t.Error(err)
 		}
-		if err := validateRange(int(someStruct.UInt8)); err != nil {
+		if err := validateIntRange(int(someStruct.UInt8)); err != nil {
 			t.Error(err)
 		}
-		if err := validateRange(int(someStruct.UInt16)); err != nil {
+		if err := validateIntRange(int(someStruct.UInt16)); err != nil {
 			t.Error(err)
 		}
-		if err := validateRange(int(someStruct.UInt32)); err != nil {
+		if err := validateIntRange(int(someStruct.UInt32)); err != nil {
 			t.Error(err)
 		}
-		if err := validateRange(int(someStruct.UInta)); err != nil {
+		if err := validateIntRange(int(someStruct.UInta)); err != nil {
 			t.Error(err)
 		}
-		if err := validateRange(int(someStruct.UInt64)); err != nil {
+		if err := validateIntRange(int(someStruct.UInt64)); err != nil {
+			t.Error(err)
+		}
+		if err := validateFloatRange(float64(someStruct.Float32)); err != nil {
+			t.Error(err)
+		}
+		if err := validateFloatRange(someStruct.Float64); err != nil {
 			t.Error(err)
 		}
 		if err := validateLen(someStruct.SString); err != nil {
@@ -595,10 +604,10 @@ func TestBoundaryAndLen(t *testing.T) {
 			}
 		}
 		for k, v := range someStruct.MIint {
-			if err := validateRange(k); err != nil {
+			if err := validateIntRange(k); err != nil {
 				t.Error(err)
 			}
-			if err := validateRange(v); err != nil {
+			if err := validateIntRange(v); err != nil {
 				t.Error(err)
 			}
 		}
@@ -807,12 +816,6 @@ func isStringLangCorrect(value string, lang langRuneBoundary) error {
 }
 
 func TestExtractNumberFromTagFail(t *testing.T) {
-	notSupportedTypeStruct := &struct {
-		Test float32 `faker:"boundary_start=5, boundary_end=10"`
-	}{}
-	if err := FakeData(&notSupportedTypeStruct); err == nil {
-		t.Error(err)
-	}
 	notSupportedStruct := &struct {
 		Test int `faker:"boundary_start=5"`
 	}{}
@@ -861,9 +864,17 @@ func validateLen(value string) error {
 	return nil
 }
 
-func validateRange(value int) error {
+func validateIntRange(value int) error {
 	if value < someStructBoundaryStart || value > someStructBoundaryEnd {
 		return fmt.Errorf("%d must be between %d and %d", value, someStructBoundaryStart,
+			someStructBoundaryEnd)
+	}
+	return nil
+}
+
+func validateFloatRange(value float64) error {
+	if value < someStructBoundaryStart || value > someStructBoundaryEnd {
+		return fmt.Errorf("%f must be between %d and %d", value, someStructBoundaryStart,
 			someStructBoundaryEnd)
 	}
 	return nil


### PR DESCRIPTION
Hey, @bxcodec.
I have no idea why float32 and float64 isn't support boundaries tags. This is why I made this PR.

What is reason of that this isn't made before? I want to discuss it cause I can don't realize some fatal reasons of this. Please, take a look.

What made by me:
* added ability to set boundaries for float32 and float64 types;
* rename old methods which supports only integers to more explicit;
* update tests;
* delete test which checks float to unsupported struct to boundaries.