### PR TITLE
fix: Always get the same value where you want to get it at random.

### DIFF
--- a/lorem.go
+++ b/lorem.go
@@ -96,8 +96,8 @@ func (l Lorem) sentence() string {
 	r, _ := RandomInt(1, 6)
 	size := len(r)
 	for key, val := range r {
-		if key == 0 {
-			sentence += strings.Title(wordList[val])
+		if key == 0 && len(wordList[val]) > 0 {
+			sentence += strings.ToUpper(wordList[val][:1]) + wordList[val][1:]
 		} else {
 			sentence += wordList[val]
 		}

--- a/phone.go
+++ b/phone.go
@@ -67,7 +67,7 @@ func (p Phone) tollfreephonenumber() string {
 		}
 		out += v
 	}
-	return fmt.Sprintf("(%s) %s", boxDigitsStart[rand.Intn(1)], out)
+	return fmt.Sprintf("(%s) %s", boxDigitsStart[rand.Intn(len(boxDigitsStart))], out)
 }
 
 // TollFreePhoneNumber generates phone numbers of type: "(888) 937-7238"
@@ -91,7 +91,7 @@ func (p Phone) e164PhoneNumber() string {
 	for _, v := range slice.IntToString(ints) {
 		out += v
 	}
-	return fmt.Sprintf("+%s%s", boxDigitsStart[rand.Intn(1)], strings.Join(slice.IntToString(ints), ""))
+	return fmt.Sprintf("+%s%s", boxDigitsStart[rand.Intn(len(boxDigitsStart))], strings.Join(slice.IntToString(ints), ""))
 }
 
 // E164PhoneNumber generates phone numbers of type: "+27113456789"


### PR DESCRIPTION
```
phone.go:70:47: SA4030: (*math/rand.Rand).Intn(n) generates a random value 0 <= x < n; that is, the generated values don't include n; rand.Intn(1) therefore always returns 0 (staticcheck)
	return fmt.Sprintf("(%s) %s", boxDigitsStart[rand.Intn(1)], out)
	                                             ^
phone.go:94:45: SA4030: (*math/rand.Rand).Intn(n) generates a random value 0 <= x < n; that is, the generated values don't include n; rand.Intn(1) therefore always returns 0 (staticcheck)
	return fmt.Sprintf("+%s%s", boxDigitsStart[rand.Intn(1)], strings.Join(slice.IntToString(ints), ""))
	                                           ^
```