### PR TITLE
feat: FakeData support recursive type

### DIFF
--- a/faker.go
+++ b/faker.go
@@ -480,9 +480,9 @@ func getValue(a interface{}, typeSeen map[reflect.Type]int) (reflect.Value, erro
 	if typeSeen[t] > recursionMaxDepth {
 		return reflect.Zero(t), nil
 	}
-	typeSeen[t] += 1
+	typeSeen[t]++
 	defer func() {
-		typeSeen[t] -= 1
+		typeSeen[t]--
 	}()
 	k := t.Kind()
 

--- a/faker_test.go
+++ b/faker_test.go
@@ -2235,7 +2235,7 @@ type Nested2 struct {
 }
 
 func TestFakeData_RecursiveType(t *testing.T) {
-	toJson := func(val interface{}) string {
+	toJSON := func(val interface{}) string {
 		data, _ := json.MarshalIndent(val, "", "  ")
 		return string(data)
 	}
@@ -2244,13 +2244,13 @@ func TestFakeData_RecursiveType(t *testing.T) {
 		t.Errorf("%+v", err)
 		t.FailNow()
 	}
-	t.Log("binary tree node:", toJson(node1))
+	t.Log("binary tree node:", toJSON(node1))
 	node2 := GeneralTreeNode{}
 	if err := FakeData(&node2); err != nil {
 		t.Errorf("%+v", err)
 		t.FailNow()
 	}
-	t.Log("general tree node:", toJson(node2))
+	t.Log("general tree node:", toJSON(node2))
 	t.Log("len:", len(node2.Children), "cap:", cap(node2.Children))
 
 	n := Nested1{}
@@ -2258,5 +2258,5 @@ func TestFakeData_RecursiveType(t *testing.T) {
 		t.Errorf("%+v", err)
 		t.FailNow()
 	}
-	t.Log("nested:", toJson(n))
+	t.Log("nested:", toJSON(n))
 }

--- a/faker_test.go
+++ b/faker_test.go
@@ -1,6 +1,7 @@
 package faker
 
 import (
+	"encoding/json"
 	"fmt"
 	mathrand "math/rand"
 	"reflect"
@@ -2212,4 +2213,50 @@ func TestRandomMapSliceSize(t *testing.T) {
 			t.Errorf("slice (len:%d) not expect length with test case %+v\n", len(s.Slice), expect)
 		}
 	}
+}
+
+type BinaryTreeNode struct {
+	Val   int
+	Left  *BinaryTreeNode
+	Right *BinaryTreeNode
+}
+
+type GeneralTreeNode struct {
+	Val      int
+	Children []*GeneralTreeNode
+}
+
+type Nested1 struct {
+	Nested2 *Nested2
+}
+
+type Nested2 struct {
+	Nested1 *Nested1
+}
+
+func TestFakeData_RecursiveType(t *testing.T) {
+	toJson := func(val interface{}) string {
+		data, _ := json.MarshalIndent(val, "", "  ")
+		return string(data)
+	}
+	node1 := BinaryTreeNode{}
+	if err := FakeData(&node1); err != nil {
+		t.Errorf("%+v", err)
+		t.FailNow()
+	}
+	t.Log("binary tree node:", toJson(node1))
+	node2 := GeneralTreeNode{}
+	if err := FakeData(&node2); err != nil {
+		t.Errorf("%+v", err)
+		t.FailNow()
+	}
+	t.Log("general tree node:", toJson(node2))
+	t.Log("len:", len(node2.Children), "cap:", cap(node2.Children))
+
+	n := Nested1{}
+	if err := FakeData(&n); err != nil {
+		t.Errorf("%+v", err)
+		t.FailNow()
+	}
+	t.Log("nested:", toJson(n))
 }


### PR DESCRIPTION
original `FakeData()` will cause stack overflow when it handling recursive type:
```go
type BinaryTreeNode struct {
	Val   int
	Left  *BinaryTreeNode
	Right *BinaryTreeNode
}

func TestFakeData_RecursiveType(t *testing.T) {
	toJSON := func(val interface{}) string {
		data, _ := json.MarshalIndent(val, "", "  ")
		return string(data)
	}
	node1 := BinaryTreeNode{}
	if err := FakeData(&node1); err != nil {
		t.Errorf("%+v", err)
		t.FailNow()
	}
	t.Log("binary tree node:", toJSON(node1))
}
```
```
runtime: goroutine stack exceeds 1000000000-byte limit
...
fatal error: stack overflow
```