### PR TITLE
fix panic on using map with value of aliased type

### DIFF
--- a/faker.go
+++ b/faker.go
@@ -643,6 +643,7 @@ func getValue(a interface{}) (reflect.Value, error) {
 			if err != nil {
 				return reflect.Value{}, err
 			}
+			val = val.Convert(v.Type().Elem())
 			v.SetMapIndex(key, val)
 		}
 		return v, nil


### PR DESCRIPTION
The following will panic:
```go
type Name string

func Test() {
    v := map[string]Name{}
    faker.FakeData(&v)
}
```
output:
```
panic: reflect.Value.SetMapIndex: value of type string is not assignable to type <package-name>.Name [recovered]
```